### PR TITLE
Add links to appropriate room assignments

### DIFF
--- a/src/pages/EventList/EventListItem.tsx
+++ b/src/pages/EventList/EventListItem.tsx
@@ -2,18 +2,19 @@ import {
   IonIcon,
   IonItem,
   IonLabel,
-  IonText,
   IonRippleEffect,
+  IonText,
   isPlatform,
 } from '@ionic/react';
 import dayjs from 'dayjs';
-import { arrowDropleft, arrowDropdown } from 'ionicons/icons';
+import Interweave from 'interweave';
+import { arrowDropdown, arrowDropleft } from 'ionicons/icons';
 import { isNil } from 'lodash';
 import React, { useCallback } from 'react';
 import { useCache } from 'rest-hooks';
-import Interweave from 'interweave';
 import EventResource from '../../resources/event';
 import LocationResource from '../../resources/location';
+import RoomAssignmentsButton from './RoomAssignmentsButton';
 
 interface EventDetailProps {
   readonly event: EventResource;
@@ -69,8 +70,9 @@ const EventsListItem: React.FC<EventDetailProps> = ({
         style={{ marginLeft: expanded ? '4.75rem' : '0', whiteSpace: 'normal' }}
       >
         <span>{event.title}</span>
-        <p>{location && location.name}</p>
+        <p>{location && !event.room_assignments && location.name}</p>
         {expandable && expanded && <Interweave content={event.description} />}
+        <RoomAssignmentsButton kind={event.room_assignments} />
       </IonLabel>
 
       {expandable && (

--- a/src/pages/EventList/RoomAssignmentsButton.tsx
+++ b/src/pages/EventList/RoomAssignmentsButton.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { IonButton } from '@ionic/react';
+
+export interface RoomAssignmentsButtonProps {
+  kind?: string;
+}
+
+const RoomAssignmentsButton: React.FC<RoomAssignmentsButtonProps> = ({
+  kind,
+}) => {
+  switch (kind) {
+    case 'delegation-meetings':
+      return (
+        <IonButton
+          routerLink="/rooms/delegation-meetings"
+          size="small"
+          fill="outline"
+        >
+          Find Your Room
+        </IonButton>
+      );
+    case 'country-caucus':
+      return (
+        <IonButton
+          routerLink="/rooms/country-caucus"
+          size="small"
+          fill="outline"
+        >
+          Find Your Room
+        </IonButton>
+      );
+    case 'committees':
+      return (
+        <IonButton routerLink="/rooms/committees" size="small" fill="outline">
+          Find Your Room
+        </IonButton>
+      );
+    default:
+      return null;
+  }
+};
+
+export default RoomAssignmentsButton;

--- a/src/resources/event.ts
+++ b/src/resources/event.ts
@@ -14,4 +14,6 @@ export default class EventResource extends BaseResource {
   readonly end_time: string = '';
 
   readonly location?: number;
+
+  readonly room_assignments?: string;
 }


### PR DESCRIPTION
Users can now go directly to their room assignments from the schedule.

![localhost_8100_events(iPhone 6_7_8)](https://user-images.githubusercontent.com/378216/71569623-6c655100-2a9e-11ea-9a16-13b53f11b5ba.png)
